### PR TITLE
Resolve Copy Link url - #2

### DIFF
--- a/app/src/main/java/sk/virtualvoid/nyxdroid/library/Constants.java
+++ b/app/src/main/java/sk/virtualvoid/nyxdroid/library/Constants.java
@@ -15,8 +15,8 @@ public class Constants {
 
     public static final String HTTP = "http://";
     public static final String HTTPS = "https://";
-    public static final String INDEX_WWW = "https://www.nyx.cz";
-    public static final String INDEX = "https://www.nyx.cz";
+    public static final String INDEX_WWW = "https://nyx.cz";
+    public static final String INDEX = "https://nyx.cz";
 
     public static final String AUTH_NICK = "AuthNick";
     public static final String AUTH_TOKEN = "AuthToken";


### PR DESCRIPTION
Changed INDEX_WWW and INDEX - removed www, new nyx does not translate post URL properly when Copy link used. Resolves #2